### PR TITLE
fix global mutation example in fp section

### DIFF
--- a/latex/code/paradigms/fp/referential_transparency.py
+++ b/latex/code/paradigms/fp/referential_transparency.py
@@ -7,10 +7,11 @@ def f2(x):
     return x**2
 
 
-global y = 0
+y = 0
 
 
 def f3(x):
+    global y
     y += 1
     return x + y
 


### PR DESCRIPTION
Hi Kilian, thanks for this beautiful lecture! Just a small pedantic fix for the example of a function that mutates a global variable in python. On the one hand `global y = 0` gives me a syntax error (seems one cannot directly assign when declaring a variable global)) and on the other hand one has to declare a variable global inside the function that wants to mutate it (not outside).